### PR TITLE
Update task command

### DIFF
--- a/.github/pre-commit.sh
+++ b/.github/pre-commit.sh
@@ -22,6 +22,24 @@ if [ "$nonformatted" ]; then
   printf "\n"
 fi
 
+# List all nonformatted files
+files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$')
+
+# Filter files to only include those in packages containing "entity" or "dto"
+entity_files=$(echo "$files" | grep -E "entity|dto")
+
+# Some files are not formatted with golines. Print message.
+nonformatted=$(golines -l $entity_files)
+if [ "$nonformatted" ]; then
+  echo >&2 "Go files in 'entity|dto' packages must be formatted with golines. Running:"
+  for fn in $nonformatted; do
+    echo >&2 "  golines -w $PWD/$fn"
+    golines -w "$PWD/$fn"
+    git add "$PWD/$fn"
+  done
+  printf "\n"
+fi
+
 # Run linter.
 task analysis || exit 1
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -10,11 +10,13 @@ tasks:
     env:
       FILE: ".git/hooks/pre-commit"
     cmds:
-      - command -v air 2>/dev/null || go install github.com/air-verse/air@v1.61.7
-      - command -v mockgen 2>/dev/null || go install -v github.com/golang/mock/mockgen@v1.6.0 # v1.6.0
-      - command -v golangci-lint 2>/dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.2
-      - command -v gomodifytags 2>/dev/null || go install -v github.com/fatih/gomodifytags@v1.17.0
-      - command -v gotestsum 2>/dev/null || go install -v gotest.tools/gotestsum@v1.12.1
+      - go install -v github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+      - go install -v github.com/air-verse/air@latest
+      - go install -v github.com/golang/mock/mockgen@latest
+      - go install -v github.com/fatih/gomodifytags@latest
+      - go install -v github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+      - go install -v gotest.tools/gotestsum@latest
+      - go install -v github.com/segmentio/golines@latest
       - cp .github/pre-commit.sh $FILE
       - chmod +x $FILE
       - test -f $FILE && echo "$FILE exists."

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -6,7 +6,7 @@ import (
 
 func NewRestyClient(cfg Config) *resty.Client {
 	return resty.New().
-		SetHostURL(cfg.HostURL).
+		SetBaseURL(cfg.HostURL).
 		// SetHeaders(DefaultHeaders(cfg.Key)). // TODO: replace me
 		SetTimeout(cfg.Timeout).
 		SetRetryCount(cfg.RetryCount).


### PR DESCRIPTION
- Apply golines only for entity or dto package.
- Improve task command to use the latest version.
- Update deprecated resty func SetHostURL to SetBaseURL.